### PR TITLE
Remove link to wikipedia

### DIFF
--- a/docs/_includes/ohlc_page.html
+++ b/docs/_includes/ohlc_page.html
@@ -1,4 +1,4 @@
-<p class="text-justify small">In de onderstaande tabel staat de BTC/EUR prijs vastgesteld op 1 januari van ieder jaar (peildatum). Om de prijs vast te stellen is gebruik gemaakt van <a href="https://en.wikipedia.org/wiki/Open-high-low-close_chart">open-high-low-close</a> koersinformatie van exchanges.</p>
+<p class="text-justify small">In de onderstaande tabel staat de BTC/EUR prijs vastgesteld op 1 januari van ieder jaar (peildatum). Om de prijs vast te stellen is gebruik gemaakt van open-high-low-close koersinformatie van exchanges.</p>
 <h5 class="text-justify"><small>Volgens de <i class="text-warning">{{page.ohlc_type}}</i> koers:</small></h5>
 
 {% include ohlc_table.html %}


### PR DESCRIPTION
I don't like the link. Anyone who is interested in what OHLC means can search for it.