### PR TITLE
Disable switching to high low and close because the data is incorrect

### DIFF
--- a/docs/_includes/ohlc_page.html
+++ b/docs/_includes/ohlc_page.html
@@ -2,7 +2,7 @@
 <h5 class="text-justify"><small>Volgens de <i class="text-warning">{{page.ohlc_type}}</i> koers:</small></h5>
 
 {% include ohlc_table.html %}
-{% include ohlc_links.html %}
+<!-- {% include ohlc_links.html %} -->
 
 <p class="text-justify text-muted small">
   <small>In de bovenstaande tabel zijn exchanges opgenomen waarvan de prijsinformatie publiek beschikbaar is. Exchanges zonder publieke prijsinformatie hebben over het algemeen een jaarverslag met prijsinformatie beschikbaar voor hun klanten.</small>


### PR DESCRIPTION
The data for high low and close is data only collected in the 1st hour of the day, instead of over the whole day.

This Pull request disables switching to the high, low and close page until we have a way to collect the correct data.